### PR TITLE
adds missing labels for MAS and always displays program

### DIFF
--- a/_assets/js/opportunity-explorer.js
+++ b/_assets/js/opportunity-explorer.js
@@ -30,6 +30,7 @@ document.addEventListener("DOMContentLoaded", function(){
 
   const rules = {
     "construction" : {
+      "alwaysDisplay" : false,
       "industry" : [
         "all",
         "architecture",
@@ -41,11 +42,13 @@ document.addEventListener("DOMContentLoaded", function(){
       "purchase" : false,
     },
     "communications" : {
+      "alwaysDisplay" : false,
       "industry" : ["all", "itsatcom"],
       "revenue" : null,
       "purchase" : false,
     },
     "gwac" : {
+      "alwaysDisplay" : false,
       "industry" : ["all", "it", "itsatcom"],
       // TODO does it matter how much revenue / past performance your business has
       // to apply to a GWAC?
@@ -53,6 +56,7 @@ document.addEventListener("DOMContentLoaded", function(){
       "purchase" : false,
     },
     "mas" : {
+      "alwaysDisplay" : true,
       // Note: this list drawn from the 12 MAS categories
       // https://www.gsa.gov/buying-selling/purchasing-programs/gsa-multiple-award-schedule/gsa-schedule-offerings/mas-categories
       "industry" : [
@@ -77,17 +81,20 @@ document.addEventListener("DOMContentLoaded", function(){
       "purchase" : false
     },
     "masit" : {
+      "alwaysDisplay" : false,
       "industry" : ["all", "it", "itsatcom"],
       "revenue" : true,
       "purchase" : false
     },
     "fastlane" : {
+      "alwaysDisplay" : false,
       "industry" : ["all", "it", "itsatcom"],
       // TODO is past performance required for FAStlane?
       "revenue" : null,
       "purchase" : false,
     },
     "springboard" : {
+      "alwaysDisplay" : false,
       "industry" : ["all", "it", "itsatcom"],
       "revenue" : false,
       "purchase" : false,
@@ -98,18 +105,29 @@ document.addEventListener("DOMContentLoaded", function(){
 
   for (let program of programDivs) {
     let programRules = rules[program.id];
+    let alwaysDisplay = programRules["alwaysDisplay"]
 
     let industryMatch = programRules["industry"].includes(industry);
     let revenueMatch = checkRule(programRules["revenue"], revenue);
     let purchaseMatch = checkRule(programRules["purchase"], purchase);
 
-    if (!industryMatch || !revenueMatch || !purchaseMatch) {
-      program.style.display = "none";
+    if (alwaysDisplay) {
+      // if the program is being displayed, check if its individual criteria
+      // for revenue and purchase have been met and if so, hide those warnings
+      if (revenueMatch) { hideWarning("revenue", program.id); }
+      if (purchaseMatch) { hideWarning("purchase", program.id); }
+    } else if (!industryMatch || !revenueMatch || !purchaseMatch) {
+      program.classList.add("display-none");
     }
   }
 
   function checkRule(rule, param) {
     // if the rule is null then this particular question does not apply
     return (rule == null) ? true : (rule == param)
+  }
+
+  function hideWarning(type, programId) {
+    let warning = document.getElementById(programId + "-" + type);
+    if (warning) { warning.classList.add("display-none"); }
   }
 });

--- a/_data/opportunity-explorer-answers.yml
+++ b/_data/opportunity-explorer-answers.yml
@@ -21,6 +21,13 @@ programs:
       Under the MAS Program, GSA issues long-term government-wide contracts
       that provide federal, state, and local government buyers access to
       commercial products, services, and solutions at pre-negotiated pricing.
+    missingLabels:
+      - name: revenue
+        desc: |-
+          You must be in business for 2 years and show $25,000 in revenue to
+          become a MAS vendor
+      - name: purchase
+        desc: The MAS program focuses on sales which exceed $10K per purchase
     # SOURCE
     # https://www.gsa.gov/technology/technology-purchasing-programs/telecommunications-and-network-services
   - name: Multiple Award Schedules IT (MAS IT)

--- a/_pages/opportunity-explorer-results.html
+++ b/_pages/opportunity-explorer-results.html
@@ -18,6 +18,17 @@ permalink: /opportunity-explorer-results/
           <div id="{{ program.id }}" class="program">
             <h3>{{ program.name }}</h3>
             <p>{{ program.desc }}</p>
+            <div class="program-missing">
+              {% for label in program.missingLabels %}
+                <div class="usa-alert usa-alert--info usa-alert--slim" id="{{program.id}}-{{ label.name }}">
+                  <div class="usa-alert__body">
+                    <p class="usa-alert__text">
+                      {{ label.desc }}
+                    </p>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
             <p><a class="usa-link" href="javascript:void(0)">Learn more about {{ program.name }}</a></p>
           </div>
         {% endfor %}

--- a/spec/opportunity_explorer_results_spec.rb
+++ b/spec/opportunity_explorer_results_spec.rb
@@ -36,8 +36,8 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
         expect(page).to have_content("Programs")
       end
 
-      it "does not have any programs" do
-        expect(page).not_to have_content("Multiple Award Schedules (MAS)")
+      it "does not have any programs except MAS" do
+        expect(page).to have_content("Multiple Award Schedules (MAS)")
         expect(page).not_to have_content("Government-wide Acquisition Contracts (GWAC)")
       end
     end
@@ -144,6 +144,12 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
           expect(page).to have_content("Construction and building maintenance")
           expect(page).to have_content("Telecommunications and network services")
         end
+
+        it "does not have any missing info for MAS" do
+          expect(page).not_to have_content("You must be in business for 2 years and show $25,000 in revenue to
+          become a MAS vendor")
+          expect(page).not_to have_content("The MAS program focuses on sales which exceed $10K per purchase")
+        end
       end
 
       context "when it is an IT company" do
@@ -169,22 +175,30 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
         end
       end
       context "when it is a construction and building maintenance company" do
-        it "should display construction and building maintenance IDIQ" do
+        it "should display construction and building maintenance IDIQ as well as MAS" do
           visit "/opportunity-explorer-results/index.html?industry=construction&revenue=1&purchase=0"
           expect(page).to have_content("Construction and building maintenance")
+          expect(page).to have_content("Multiple Award Schedules (MAS)")
 
-          expect(page).not_to have_content("Multiple Award Schedules (MAS)")
           expect(page).not_to have_content("Government-wide Acquisition Contracts (GWAC)")
         end
       end
     end
 
     context "when the company is not well-established" do
-      it "shows springboard and GWAC programs" do
+      before :each do
         visit "/opportunity-explorer-results/index.html?industry=it&revenue=0&purchase=0"
+      end
+
+      it "shows springboard and GWAC programs" do
         expect(page).to have_content("FASt Lane")
         expect(page).to have_content("Startup Springboard")
         expect(page).to have_content("Government-wide Acquisition Contracts (GWAC)")
+      end
+
+      it "shows missing requirements for MAS" do
+        expect(page).not_to have_content("You must be in business for 2 years and show $25,000 in revenue to
+        become a MAS vendor")
       end
     end
   end
@@ -192,9 +206,11 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
   context "when a company sells only micropurchases" do
     context "and they are well-established" do
       context "when industry not selected" do
-        it "shows no program results" do
+        it "shows no program results except for MAS with a missing requirement" do
           visit "/opportunity-explorer-results/index.html?industry=all&revenue=1&purchase=1"
-          expect(page).not_to have_content("Multiple Award Schedules (MAS)")
+          expect(page).to have_content("Multiple Award Schedules (MAS)")
+          expect(page).to have_content("The MAS program focuses on sales which exceed $10K per purchase")
+
           expect(page).not_to have_content("Multiple Award Schedules IT (MAS IT)")
           expect(page).not_to have_content("FASt Lane")
           expect(page).not_to have_content("Government-wide Acquisition Contracts (GWAC)")
@@ -203,9 +219,10 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
         end
       end
       context "when industry is IT" do
-        it "shows no program results" do
+        it "shows no program results except MAS" do
           visit "/opportunity-explorer-results/index.html?industry=it&revenue=1&purchase=1"
-          expect(page).not_to have_content("Multiple Award Schedules (MAS)")
+          expect(page).to have_content("Multiple Award Schedules (MAS)")
+
           expect(page).not_to have_content("Multiple Award Schedules IT (MAS IT)")
           expect(page).not_to have_content("FASt Lane")
           expect(page).not_to have_content("Government-wide Acquisition Contracts (GWAC)")
@@ -215,9 +232,12 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
       end
     end
     context "and they are not well-established" do
-      it "shows no program results" do
+      it "shows no program results except MAS with missing requirement" do
         visit "/opportunity-explorer-results/index.html?industry=all&revenue=0&purchase=1"
-        expect(page).not_to have_content("Multiple Award Schedules (MAS)")
+        expect(page).to have_content("Multiple Award Schedules (MAS)")
+        expect(page).to have_content("The MAS program focuses on sales which exceed $10K per purchase")
+        expect(page).to have_content("You must be in business for 2 years and show $25,000 in revenue to become a MAS vendor")
+
         expect(page).not_to have_content("Multiple Award Schedules IT (MAS IT)")
         expect(page).not_to have_content("FASt Lane")
         expect(page).not_to have_content("Government-wide Acquisition Contracts (GWAC)")


### PR DESCRIPTION
closes #https://github.com/18F/gsa-small-business-experience/issues/101

Preview https://federalist-35400506-693f-4f4d-815c-e4fb7841233f.app.cloud.gov/preview/18f/gsa-small-business-experience/mas-display/opportunity-explorer-results/?industry=it&revenue=0&purchase=1

![image](https://user-images.githubusercontent.com/2480492/160694381-032419ac-d4b4-49bb-b761-44863d7826b4.png)

(above: multiple award schedules shows as a program result. There are two blue info alerts below it explaining missing criteria)