### PR TITLE
changes ways to work navigation tab style

### DIFF
--- a/_assets/css/theme/_gsa-sbe-content.scss
+++ b/_assets/css/theme/_gsa-sbe-content.scss
@@ -149,29 +149,47 @@ iframe {
 }
 
 #wtw-nav {
+  $btn-tab-active-color: #1A4480;
+  $btn-tab-base-color: #F0F0F0;
+
+  border-bottom: solid 9px $btn-tab-active-color;
+
+  .active, .active:hover, .active:focus {
+    background-color: $btn-tab-active-color;
+    color: $btn-tab-base-color;
+  }
+
   button {
     // override default button styles
-    background-color: transparent;
-    border-top: none;
+    border-bottom: none;
     border-left: none;
     border-right: none;
+    border-top: none;
 
-    // custom button styles
-    border-bottom: solid 9px #F3F3F3;
-    color: #71767A;
-    text-decoration: none;
+    background-color: $btn-tab-base-color;
+    color: $btn-tab-active-color;
+
+    @media screen and (min-width: 640px) {
+      // when side by side, borders should be between buttons,
+      // not on the outside edges
+      &:not(:first-child) {
+        border-left: solid #FFF 4px;
+      }
+      &:not(:last-child) {
+        border-right: solid #FFF 4px;
+      }
+    }
 
     &:hover, &:focus {
-      // TODO incorporate mixin or function for bg-primary-light
-      border-bottom-color: #73b3e7;
+      background-color: #73b3e7;
       color: #000;
       cursor: pointer;
     }
-  }
 
-  .active, .active:hover, .active:focus {
-    border-bottom-color: #005EA2;
-    color: #000;
+    h3 {
+      @include u-margin-bottom(2);
+      @include u-text('normal');
+    }
   }
 }
 

--- a/_includes/home/wtw-nav.html
+++ b/_includes/home/wtw-nav.html
@@ -1,12 +1,12 @@
 <div class="grid-row text-center" id="wtw-nav" role="tablist">
   <button type="button" role="tab" aria-selected="true" aria-controls="wtw-schedule-tab" class="tablet:grid-col-4 active" id="wtw-schedule" tabindex="0">
-    <h3 class="margin-bottom-0">Contract Schedule</h3>
+    <h3>Become a Vendor</h3>
   </button>
   <button type="button" role="tab" aria-selected="false" aria-controls="wtw-opportunities-tab" class="tablet:grid-col-4" id="wtw-opportunities" tabindex="0">
-    <h3 class="margin-bottom-0">Open Market Opportunities</h3>
+    <h3>Open Market Opportunities</h3>
   </button>
   <button type="button" role="tab" aria-selected="false" aria-controls="wtw-subcontracts-tab" class="tablet:grid-col-4" id="wtw-subcontracts" tabindex="0">
-    <h3 class="margin-bottom-0">Subcontract & Partnerships</h3>
+    <h3>Subcontract & Partnerships</h3>
   </button>
 </div>
 


### PR DESCRIPTION
Active state
![image](https://user-images.githubusercontent.com/2480492/161281446-0a7054d7-2d93-4dff-9f52-d4e27c789f28.png)

Hover state
![image](https://user-images.githubusercontent.com/2480492/161281539-11c4d982-a927-415a-998d-8a7d9dec271c.png)

Focus state
![image](https://user-images.githubusercontent.com/2480492/161281653-65eabb91-9869-4958-8498-4a3e2d3f769f.png)

Mobile
![image](https://user-images.githubusercontent.com/2480492/161282932-2392a286-fdb4-4227-998e-b7027ade7e1e.png)

I don't love how the focus looks at the moment, but I was having trouble getting the `grid-gap` class to display the way we wanted it to, since it uses padding for the elements and their gray background meant just more gray.  Instead, I'm using white borders, hence why the focus looks bigger than the buttons.  I'm open to suggestions about how to handle that within the USWDS grid / row / column system.

Preview on federalist:  https://federalist-35400506-693f-4f4d-815c-e4fb7841233f.app.cloud.gov/preview/18f/gsa-small-business-experience/tabs/

Closes #118 
Closes #121 