### PR TITLE
Fake data

### DIFF
--- a/_assets/css/theme/_gsa-sbe-content.scss
+++ b/_assets/css/theme/_gsa-sbe-content.scss
@@ -214,6 +214,12 @@ iframe {
 
 // OPPORTUNITY EXPLORER RESULTS
 
+#contracts-table {
+  td, th {
+    background-color: #F3F3F3;
+  }
+}
+
 h2.opp-exp-results {
   border-bottom: 1px solid black;
   padding-bottom: 1em;

--- a/_assets/js/opportunity-explorer.js
+++ b/_assets/js/opportunity-explorer.js
@@ -55,4 +55,17 @@ document.addEventListener("DOMContentLoaded", function(){
     let warning = document.getElementById(programId + "-" + type);
     if (warning) { warning.classList.add("display-none"); }
   }
+
+  // CONTRACT EXAMPLES
+
+  // Hide any contracts which are not from the selected industry
+
+  // TODO what to display if no industry selected?
+  // TODO skip iterating through each and hide table if none selected?
+  contractDivs = document.getElementById("contracts").children;
+  for (let row of contractDivs) {
+    if (!row.classList.contains("contract-" + industry)) {
+      row.classList.add("display-none");
+    }
+  }
 });

--- a/_assets/js/opportunity-explorer.js
+++ b/_assets/js/opportunity-explorer.js
@@ -59,13 +59,16 @@ document.addEventListener("DOMContentLoaded", function(){
   // CONTRACT EXAMPLES
 
   // Hide any contracts which are not from the selected industry
+  // If no industry is selected, hide all contracts
 
-  // TODO what to display if no industry selected?
-  // TODO skip iterating through each and hide table if none selected?
-  contractDivs = document.getElementById("contracts").children;
-  for (let row of contractDivs) {
-    if (!row.classList.contains("contract-" + industry)) {
-      row.classList.add("display-none");
+  if (industry == "") {
+    document.getElementById("contracts-table").classList.add("display-none");
+  } else {
+    contractDivs = document.getElementById("contracts").children;
+    for (let row of contractDivs) {
+      if (!row.classList.contains("contract-" + industry)) {
+        row.classList.add("display-none");
+      }
     }
   }
 });

--- a/_data/opportunity-explorer-answers-contracts.yml
+++ b/_data/opportunity-explorer-answers-contracts.yml
@@ -1,0 +1,141 @@
+- industry: all
+  items:
+    - title: Web Site Hosting
+      agency: Congressional Budget Office
+    - title: Ink Toner Boxes
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: Hotel Accommodations/Lodging
+      agency: JUSTICE, DEPT OF
+
+- industry: architecture
+  items:
+    - title: Supplemental Architecture and Engineering Services for OK
+      agency: PUBLIC BUILDINGS SERVICE
+    - title: Design-Build Construction of Plant Biosence Research Facility, WA
+      agency: DEPT OF DEFENSE
+
+- industry: construction
+  items:
+    - title: Fort Hood Renovate and Repair Architectural Features IDIQ
+      agency: DEPT OF DEFENSE
+    - title: Harbor Refuge Dwelling Rehabilitation
+      agency: NATIONAL PARK SERVICE
+    - title: Blackfeet Reservation Apartment Complex
+      agency: INDIAN HEALTH SERVICE
+
+- industry: facilities
+  items:
+    - title: Mount Rushmore Custodial Services
+      agency: NATIONAL PARK SERVICE
+    - title: Vault Pumping Contract
+      agency: BUREAU OF LAND MANAGEMENT
+    - title: Grounds Maintenance Services, Ithaca NY
+      agency: DEPT OF DEFENSE
+
+- industry: furniture
+  items:
+    - title: Cardio Tilt Table
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: JFB, GSA D&C 5th to 18th Floor Furniture
+      agency: GENERAL SERVICES ADMINISTRATION
+
+- industry: human
+  items:
+    - title: FERS and FERS LEO Retirement Planning
+      agency: JUSTICE, DEPT OF
+    - title: J&A for Human Resources Specialist Support Services
+      agency: DEPT OF DEFENSE
+    - title: Human Resources (HR) Support Services
+      agency: NUCLEAR REGULATORY COMMISSION
+
+- industry: industrial
+  items:
+    - title: Radio Frequency (RF) Welder
+      agency: DEPT OF DEFENSE
+    - title: 300 MhZ Solid-State NMR Spectrometer Console
+      agency: COMMERCE, DEPT OF
+
+- industry: interior
+  items:
+    - title: Port of Entry Project - A/E Services
+      agency: GENERAL SERVICES ADMINISTRATION
+    - title: Relocate PHysical Medicine and Rehabilitation to 4th Floor
+      agency: VETERANS AFFAIRS, DEPT OF
+
+- industry: it
+  items:
+    - title: PM/CM Engineering Support for VACCHCS IAW
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: Purchase Software as a Service (SAAS) code and platforms
+      agency: SMALL BUSINESS ADMINISTRATION
+    - title: Web Site Hosting
+      agency: Congressional Budget Office
+
+- industry: itsatcom
+  items:
+    - title: Cellular telephone services
+      agency: STATE, DEPT OF
+    - title: Notice of Intent to Solicit and Award Contract for Beeper Services
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: Tactical Network Routers
+      agency: DEPT OF DEFENSE
+
+- industry: office
+  items:
+    - title: Ink Toner Boxes
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: Packing, packaging, preservation, and marking services
+      agency: GENERAL SERVICES ADMINISTRATION
+    - title: Large Format Production Printer
+      agency: DEPT OF DEFENSE
+
+- industry: professional
+  items:
+    - title: FY22 Full Service Contract for SPS Getinge Equipment
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: Surgical Instruments for Northport VA Medical System
+      agency: VETERANS AFFAIRS, DEPT OF
+
+- industry: realestate
+  items:
+    - title: Marketing, Brokerage Services, & Lease Management of US GSA Lamar Building
+      agency: GENERAL SERVICES ADMINISTRATION
+    - title: "Iowa Land Appraisals: Agricultural Conservation Easement Program"
+      agency: AGRICULTURE, DEPT OF
+
+- industry: science
+  items:
+    - title: Surgical Instruments for Northport VA Medical System
+      agency: VETERANS AFFAIRS, DEPT OF
+    - title: 300 MhZ Solid-State NMR Spectrometer Console
+      agency: COMMERCE, DEPT OF
+
+- industry: security
+  items:
+    - title: NP Aerospace Bomb Suits
+      agency: JUSTICE, DEPT OF
+    - title: Smithsonian Tropical Research Institute Guard Force and Control Room Operator Services
+      agency: SMITHSONIAN INSTITUTION
+
+- industry: transport
+  items:
+    - title: New 55 Ton Lowboy Trailer
+      agency: INTERIOR, DEPT OF THE
+    - title: Boat Trailer
+      agency: DEPT OF DEFENSE
+    - title: Hood River Ranger District Dirt Bike Purchase
+      agency: AGRICULTURE, DEPT OF
+
+- industry: travel
+  items:
+    - title: Hotel Accommodations/Lodging
+      agency: JUSTICE, DEPT OF
+    - title: DTMO Travel Management Company Services for Travel Area-3
+      agency: DEPT OF DEFENSE
+
+- industry: other
+  items:
+    - title: Horse Mountain Wildlife Water Catchment
+      agency: INTERIOR, DEPT OF THE
+    - title: 2027 Gershwin Prize IDIQ
+      agency: LIBRARY OF CONGRESS

--- a/_data/opportunity-explorer-answers-contracts.yml
+++ b/_data/opportunity-explorer-answers-contracts.yml
@@ -1,7 +1,7 @@
 - industry: all
   items:
-    - title: Web Site Hosting
-      agency: Congressional Budget Office
+    - title: Diversity, Equity, Inclusion, and Accessibility Training
+      agency: LABOR, DEPT OF
     - title: Ink Toner Boxes
       agency: VETERANS AFFAIRS, DEPT OF
     - title: Hotel Accommodations/Lodging
@@ -41,10 +41,10 @@
 
 - industry: human
   items:
-    - title: FERS and FERS LEO Retirement Planning
-      agency: JUSTICE, DEPT OF
-    - title: J&A for Human Resources Specialist Support Services
+    - title: AF Band Diversity and Inclusion Training
       agency: DEPT OF DEFENSE
+    - title: Diversity, Equity, Inclusion, and Accessibility Training
+      agency: LABOR, DEPT OF
     - title: Human Resources (HR) Support Services
       agency: NUCLEAR REGULATORY COMMISSION
 

--- a/_data/opportunity-explorer-answers-programs.yml
+++ b/_data/opportunity-explorer-answers-programs.yml
@@ -90,7 +90,7 @@ rules:
       - itsatcom
       - office
       - other # miscellaneous category
-      - prof
+      - professional
       - realestate
       - science
       - security

--- a/_data/opportunity-explorer-questions.yml
+++ b/_data/opportunity-explorer-questions.yml
@@ -28,7 +28,7 @@
     - label: Office management
       value: office
     - label: Professional services
-      value: prof
+      value: professional
     - label: Real Estate
       value: realestate
     - label: Scientific management & solutions
@@ -39,8 +39,6 @@
       value: security
     - label: Travel
       value: travel
-    # - label: Real estate
-    #   value: realestate
     - label: Other
       value: other
 

--- a/_pages/opportunity-explorer-results.html
+++ b/_pages/opportunity-explorer-results.html
@@ -96,7 +96,7 @@ permalink: /opportunity-explorer-results/
 
       <p>Explore contracts and contract data at SAM.gov</p>
 
-      <table class="usa-table usa-table--borderless">
+      <table class="usa-table usa-table--borderless" id="contracts-table">
         <thead>
           <tr>
             <th scope="col">Contract Title</th>

--- a/_pages/opportunity-explorer-results.html
+++ b/_pages/opportunity-explorer-results.html
@@ -95,9 +95,26 @@ permalink: /opportunity-explorer-results/
       <h2 class="font-heading-sm margin-top-0">Explore Current & Past Contracts</h2>
 
       <p>Explore contracts and contract data at SAM.gov</p>
-      <div class="text-placeholder"></div>
-      <div class="text-placeholder"></div>
-      <div class="text-placeholder"></div>
+
+      <table class="usa-table usa-table--borderless">
+        <thead>
+          <tr>
+            <th scope="col">Contract Title</th>
+            <th scope="col">Agency</th>
+          </tr>
+        </thead>
+        <tbody id="contracts">
+          {% for industry in site.data.opportunity-explorer-answers-contracts %}
+            {% for item in industry.items %}
+              <tr class="contract contract-{{industry.industry}}">
+                <th scope="row">{{ item.title }}</th>
+                <td>{{ item.agency }}</td>
+              </tr>
+            {% endfor %}
+          {% endfor %}
+        </tbody>
+      </table>
+
       <p><a href="javascript:void(0)" class="usa-link">Explore more at SAM.gov ></a></p>
 
       <h2 class="font-heading-sm margin-top-5">Forecasting of Contract Opportunities</h2>

--- a/spec/opportunity_explorer_results_spec.rb
+++ b/spec/opportunity_explorer_results_spec.rb
@@ -199,4 +199,66 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
       become a MAS vendor")
     end
   end
+
+  # CONTRACTS
+
+  context "when no industry is selected" do
+    it "hides the table with contracts" do
+      visit "/opportunity-explorer-results/index.html?industry="
+      expect(page).not_to have_content("Contract Title")
+    end
+  end
+
+  context "when industry is selected" do
+    context "and industry is all" do
+      before :each do
+        visit "/opportunity-explorer-results/index.html?industry=all"
+      end
+      it "shows contracts from a range of disciplines" do
+        expect(page).to have_content("Web Site Hosting")
+        expect(page).to have_content("Ink Toner Boxes")
+        expect(page).to have_content("Hotel Accommodations/Lodging")
+      end
+      it "does not show those contracts that should be hidden" do
+        expect(page).not_to have_content("Mount Rushmore Custodial Services")
+        expect(page).not_to have_content("Port of Entry Project - A/E Services")
+        expect(page).not_to have_content("Large Format Production Printer")
+      end
+    end
+
+    context "and industry is architecture" do
+      before :each do
+        visit "/opportunity-explorer-results/index.html?industry=architecture"
+      end
+      it "shows contracts for architecture" do
+        expect(page).to have_content("Supplemental Architecture and Engineering Services for OK")
+        expect(page).to have_content("Design-Build Construction of Plant Biosence Research Facility, WA")
+      end
+      it "does not show unrelated industry contracts" do
+        expect(page).not_to have_content("300 MhZ Solid-State NMR Spectrometer Console")
+        expect(page).not_to have_content("NP Aerospace Bomb Suits")
+      end
+      it "has two contract results" do
+        expect(page).to have_css("tr.contract", count: 2)
+      end
+    end
+
+    context "and industry is itsatcom" do
+      before :each do
+        visit "/opportunity-explorer-results/index.html?industry=itsatcom"
+      end
+      it "shows contracts for itsatcom" do
+        expect(page).to have_content("Cellular telephone services")
+        expect(page).to have_content("Notice of Intent to Solicit and Award Contract for Beeper Services")
+        expect(page).to have_content("Tactical Network Routers")
+      end
+      it "does not show unrelated industry contracts" do
+        expect(page).not_to have_content("PM/CM Engineering Support for VACCHCS IAW")
+        expect(page).not_to have_content("Horse Mountain Wildlife Water Catchment")
+      end
+      it "has three contract results" do
+        expect(page).to have_css("tr.contract", count: 3)
+      end
+    end
+  end
 end

--- a/spec/opportunity_explorer_results_spec.rb
+++ b/spec/opportunity_explorer_results_spec.rb
@@ -215,9 +215,12 @@ describe "/opportunity-explorer-results", type: :feature, js: true do
         visit "/opportunity-explorer-results/index.html?industry=all"
       end
       it "shows contracts from a range of disciplines" do
-        expect(page).to have_content("Web Site Hosting")
+        expect(page).to have_content("Diversity, Equity, Inclusion, and Accessibility Training")
+        expect(page).to have_content("LABOR, DEPT OF")
         expect(page).to have_content("Ink Toner Boxes")
+        expect(page).to have_content("VETERANS AFFAIRS, DEPT OF")
         expect(page).to have_content("Hotel Accommodations/Lodging")
+        expect(page).to have_content("JUSTICE, DEPT OF")
       end
       it "does not show those contracts that should be hidden" do
         expect(page).not_to have_content("Mount Rushmore Custodial Services")


### PR DESCRIPTION
Adds industry-specific contracts found in SAM.gov that are displayed on the opportunity explorer results pages

[Preview on Federalist](https://federalist-35400506-693f-4f4d-815c-e4fb7841233f.app.cloud.gov/preview/18f/gsa-small-business-experience/fakedata/)

Here is an example for "science":

![image](https://user-images.githubusercontent.com/2480492/161568113-52a7c1fb-8cc2-47e1-a1d4-a852cc205c2f.png)

Closes #119 