### PR TITLE
updates link color to meet wcag aaa scanner criteria

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -1,7 +1,7 @@
 {
   "defaults": {
     "concurrency": 1,
-    "standard": "WCAG2AA",
+    "standard": "WCAG2AAA",
     "runners": ["htmlcs"]
   }
 }

--- a/_assets/css/theme/_gsa-sbe-content.scss
+++ b/_assets/css/theme/_gsa-sbe-content.scss
@@ -30,6 +30,16 @@ h3 {
   background-color: color($theme-color-primary-dark);
 }
 
+.usa-breadcrumb__link {
+  // overriding for WCAG AAA
+  color: #005B9E;
+}
+
+.usa-link {
+  // overriding for WCAG AAA
+  color: #005898;
+}
+
 .usa-section {
   @include u-padding-bottom(2);
   @include u-padding-left(3);


### PR DESCRIPTION
Bumps accessibility scanner back up to WCAG AAA and sets link color to suggested values.

See issue #107 for a little more discussion about this

closes #107 